### PR TITLE
find_by_idのDB単体テストと結合テストを追加

### DIFF
--- a/src/test/java/com/yureto/supergt/mapper/SuperGtMapperTest.java
+++ b/src/test/java/com/yureto/supergt/mapper/SuperGtMapperTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -37,5 +38,22 @@ class SuperGtMapperTest {
                         new SuperGt(6, "荒聖治", "Studie BMW M4", "7"),
                         new SuperGt(7, "谷口信輝", "GOODSMILE RACING & TeamUKYO", "4")
                 );
+    }
+
+    @Test
+    @DataSet(value = "datasets/super_gt.yml")
+    @Transactional
+    void 指定したドライバーidが1件取得されること() {
+        Optional<SuperGt> superGt = superGtMapper.findById(1);
+        assertThat(superGt)
+                .contains(new SuperGt(1, "山本尚貴", "RAYBRIG NSX-GT", "100"));
+    }
+
+    @Test
+    @DataSet(value = "datasets/super_gt.yml")
+    @Transactional
+    void 指定したドライバーidが存在しない場合は空を返すこと() {
+        Optional<SuperGt> superGt = superGtMapper.findById(15);
+        assertThat(superGt).isEmpty();
     }
 }

--- a/src/test/java/integrationtest/SuperGtRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/SuperGtRestApiIntegrationTest.java
@@ -107,12 +107,8 @@ public class SuperGtRestApiIntegrationTest {
     @Test
     @DataSet(value = "datasets/super_gt.yml")
     @Transactional
-    void 指定したドライバーidが存在しない場合は空を返すこと() throws Exception {
-        String response = mockMvc.perform(MockMvcRequestBuilders.get("/superGt/15"))
-                .andExpect(MockMvcResultMatchers.status().isNotFound())
-                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
-        JSONAssert.assertEquals("""
-                []
-                """, response, JSONCompareMode.STRICT);
+    void 指定したドライバーidが存在しない場合は404を返すこと() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/superGt/15"))
+                .andExpect(MockMvcResultMatchers.status().isNotFound());
     }
 }

--- a/src/test/java/integrationtest/SuperGtRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/SuperGtRestApiIntegrationTest.java
@@ -83,4 +83,36 @@ public class SuperGtRestApiIntegrationTest {
 
         JSONAssert.assertEquals(expectedResponse, response, JSONCompareMode.STRICT);
     }
+
+    @Test
+    @DataSet(value = "datasets/super_gt.yml")
+    @Transactional
+    void 指定したドライバーidが1件取得されること() throws Exception {
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/superGt/1"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        String expectedResponse = """
+            {
+                "id": 1,
+                "driver": "山本尚貴",
+                "affiliatedTeam": "RAYBRIG NSX-GT",
+                "carNumber": "100"
+            }
+        """;
+
+        JSONAssert.assertEquals(expectedResponse, response, JSONCompareMode.STRICT);
+    }
+
+    @Test
+    @DataSet(value = "datasets/super_gt.yml")
+    @Transactional
+    void 指定したドライバーidが存在しない場合は空を返すこと() throws Exception {
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/superGt/15"))
+                .andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+        JSONAssert.assertEquals("""
+                []
+                """, response, JSONCompareMode.STRICT);
+    }
 }


### PR DESCRIPTION
# 概要

## DBテスト

### 指定したドライバーidが1件取得されることの実装結果
<img width="1296" alt="スクリーンショット 2024-06-04 20 47 46" src="https://github.com/yukareto/Java-final-assignment/assets/143372403/af5d4a59-3c2b-46bc-b33a-5dc260cdb648">

### 指定したドライバーidが存在しない場合は空を返すこと実装結果
<img width="1304" alt="スクリーンショット 2024-06-04 20 48 46" src="https://github.com/yukareto/Java-final-assignment/assets/143372403/9022d89a-dc50-4d7b-9445-ab8c95394807">


## 結合テスト

### 指定したドライバーidが1件取得されること実装結果
<img width="1321" alt="スクリーンショット 2024-06-04 21 50 14" src="https://github.com/yukareto/Java-final-assignment/assets/143372403/59ef5629-1e2b-442e-96a3-96f85be17d61">

### 指定したドライバーidが存在しない場合の実装結果
<img width="1325" alt="スクリーンショット 2024-06-04 22 27 14" src="https://github.com/yukareto/Java-final-assignment/assets/143372403/29d4793e-c3cd-4be2-a337-68d57b83b245">



実装したコードのコミットハッシュです⬇️
0ed8619d4752f3f77e2f71046a63f4933bf94e8b