### PR TITLE
deleteのDBテストと結合テストを実装

### DIFF
--- a/src/main/java/com/yureto/supergt/controller/SuperGtController.java
+++ b/src/main/java/com/yureto/supergt/controller/SuperGtController.java
@@ -1,7 +1,6 @@
 package com.yureto.supergt.controller;
 
 import com.yureto.supergt.controller.request.SuperGtRequest;
-import com.yureto.supergt.controller.response.SuperGtResponse;
 import com.yureto.supergt.entity.SuperGt;
 import com.yureto.supergt.service.SuperGtService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -57,9 +56,8 @@ public class SuperGtController {
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<SuperGtResponse> delete(@PathVariable("id") Integer id) {
-        Integer deletedId = superGtService.delete(id);
-        SuperGtResponse message = new SuperGtResponse("driver deleted");
-        return ResponseEntity.ok(message);
+    public ResponseEntity<Void> delete(@PathVariable("id") Integer id) {
+        superGtService.delete(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/test/java/com/yureto/supergt/mapper/SuperGtMapperTest.java
+++ b/src/test/java/com/yureto/supergt/mapper/SuperGtMapperTest.java
@@ -85,4 +85,13 @@ class SuperGtMapperTest {
         assertThat(superGt)
                 .contains(new SuperGt(1, "福住仁嶺", "ENEOS X PRIME GR Supra", "14"));
     }
+
+    @Test
+    @DataSet(value = "datasets/super_gt.yml")
+    @Transactional
+    void 指定したドライバーidが削除されること() {
+        superGtMapper.delete(7);
+        Optional<SuperGt> superGt = superGtMapper.findById(7);
+        assertThat(superGt).isEmpty();
+    }
 }

--- a/src/test/java/integrationtest/SuperGtRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/SuperGtRestApiIntegrationTest.java
@@ -170,4 +170,12 @@ public class SuperGtRestApiIntegrationTest {
 
         JSONAssert.assertEquals(expectedResponse, response, JSONCompareMode.LENIENT);
     }
+
+    @Test
+    @DataSet(value = "datasets/super_gt.yml")
+    @Transactional
+    void 指定したドライバーidが削除されること() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.delete("/superGt/7"))
+                .andExpect(MockMvcResultMatchers.status().isNoContent());
+    }
 }

--- a/src/test/java/integrationtest/SuperGtRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/SuperGtRestApiIntegrationTest.java
@@ -1,6 +1,7 @@
 package integrationtest;
 
 import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.spring.api.DBRider;
 import com.yureto.supergt.SupergtApplication;
 import org.junit.jupiter.api.Test;
@@ -173,6 +174,7 @@ public class SuperGtRestApiIntegrationTest {
 
     @Test
     @DataSet(value = "datasets/super_gt.yml")
+    @ExpectedDataSet(value = "datasets/super_gt_after_deletion.yml")
     @Transactional
     void 指定したドライバーidが削除されること() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.delete("/superGt/7"))

--- a/src/test/resources/datasets/super_gt_after_deletion.yml
+++ b/src/test/resources/datasets/super_gt_after_deletion.yml
@@ -1,0 +1,25 @@
+super_gt:
+  - id: 1
+    driver: 山本尚貴
+    affiliated_team: RAYBRIG NSX-GT
+    car_number: 100
+  - id: 2
+    driver: 大湯都史樹
+    affiliated_team: ARTA MUGEN NSX-GT
+    car_number: 8
+  - id: 3
+    driver: 立川裕路
+    affiliated_team: ZENT CERUMO GR Supra
+    car_number: 38
+  - id: 4
+    driver: 蒲生尚弥
+    affiliated_team: LEON PYRAMID AMG
+    car_number: 65
+  - id: 5
+    driver: 井口卓人
+    affiliated_team: SUBARU BRZ R&D SPORT
+    car_number: 61
+  - id: 6
+    driver: 荒聖治
+    affiliated_team: Studie BMW M4
+    car_number: 7


### PR DESCRIPTION
# 概要

## deleteのDBテストと結合テストを実装 しました。

###  DBテストの実装結果
<img width="1356" alt="スクリーンショット 2024-06-13 8 28 30" src="https://github.com/yukareto/Java-final-assignment/assets/143372403/5d96eab7-e9cf-4e48-b276-cee40d4eca37">


### 結合テストの実装結果
<img width="1376" alt="スクリーンショット 2024-06-13 8 29 45" src="https://github.com/yukareto/Java-final-assignment/assets/143372403/a76910c2-8742-45c3-9dd5-ff180675e47c">


## 実装した内容のコミットハッシュです⬇️
8516151966a81045d7b1e864ea323c7babacca44